### PR TITLE
Add Jest Custom Matchers for Accessible AtomicDesign

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ const customJestConfig = {
   moduleDirectories: ["node_modules", "<rootDir>/"],
   testEnvironment: "jest-environment-jsdom",
   setupFiles: ["./jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/src/tests/jest.customMatchers.ts"],
   moduleNameMapper: { "^@/(.*)$": "<rootDir>/src/$1" },
   resolver: "<rootDir>/jest.resolver.js",
   reporters: [

--- a/src/components/atoms/Alert/Alert.test.tsx
+++ b/src/components/atoms/Alert/Alert.test.tsx
@@ -6,11 +6,15 @@ import * as stories from "./Alert.stories";
 const { Success, Fail } = composeStories(stories);
 
 describe("src/components/atoms/Alert/Alert.test.tsx", () => {
-  test("[role=alert]であること", () => {
+  test("Atom である", () => {
+    const { container } = render(<Success />);
+    expect(container).toBeAtom();
+  });
+  test("[role=alert]である", () => {
     const { getByRole } = render(<Success />);
     expect(getByRole("alert")).toHaveTextContent("作成しました");
   });
-  test("[role=alert]であること", () => {
+  test("失敗時の見た目は異なる", () => {
     const { getByRole } = render(<Fail />);
     expect(getByRole("alert")).toHaveTextContent("エラーが発生しました");
   });

--- a/src/components/atoms/AnchorButton/AnchorButton.test.tsx
+++ b/src/components/atoms/AnchorButton/AnchorButton.test.tsx
@@ -7,11 +7,15 @@ const { Default, Disabled } = composeStories(stories);
 
 describe("src/components/atoms/AnchorButton/AnchorButton.test.tsx", () => {
   const options = { name: "送信する" };
-  test("[role=button]であること", () => {
+  test("Atom である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeAtom();
+  });
+  test("[role=button]である", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("button", options)).toBeInTheDocument();
   });
-  test("[aria-disabled=true]であること", () => {
+  test("[aria-disabled=true]である", () => {
     const { getByRole } = render(<Disabled />);
     // SEE: https://github.com/testing-library/jest-dom/issues/144
     expect(getByRole("button", options)).toHaveAttribute(

--- a/src/components/atoms/AnchorText/AnchorText.test.tsx
+++ b/src/components/atoms/AnchorText/AnchorText.test.tsx
@@ -7,7 +7,11 @@ const { Default } = composeStories(stories);
 
 describe("src/components/atoms/AnchorText/AnchorText.test.tsx", () => {
   const options = { name: "送信する" };
-  test("[role=link]であること", () => {
+  test("Atom である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeAtom();
+  });
+  test("[role=link]である", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("link", options)).toBeInTheDocument();
   });

--- a/src/components/atoms/Button/Button.test.tsx
+++ b/src/components/atoms/Button/Button.test.tsx
@@ -7,11 +7,15 @@ const { Default, Disabled } = composeStories(stories);
 
 describe("src/components/atoms/Button/Button.test.tsx", () => {
   const options = { name: "送信する" };
-  test("[role=button]であること", () => {
+  test("Atom である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeAtom();
+  });
+  test("[role=button]である", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("button", options)).toBeInTheDocument();
   });
-  test("[disabled=true]であること", () => {
+  test("[disabled=true]である", () => {
     const { getByRole } = render(<Disabled />);
     expect(getByRole("button", options)).toBeDisabled();
   });

--- a/src/components/atoms/Textarea/Textarea.test.tsx
+++ b/src/components/atoms/Textarea/Textarea.test.tsx
@@ -6,7 +6,11 @@ import * as stories from "./Textarea.stories";
 const { Default } = composeStories(stories);
 
 describe("src/components/atoms/Textarea/Textarea.test.tsx", () => {
-  test("[role=textbox]であること", () => {
+  test("Atom である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeAtom();
+  });
+  test("[role=textbox]である", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("textbox")).toBeInTheDocument();
   });

--- a/src/components/atoms/Textbox/Textbox.test.tsx
+++ b/src/components/atoms/Textbox/Textbox.test.tsx
@@ -6,11 +6,15 @@ import * as stories from "./Textbox.stories";
 const { Default, Spinbutton } = composeStories(stories);
 
 describe("src/components/Textbox/Textbox.test.tsx", () => {
-  test("[role=textbox]であること", () => {
+  test("Atom である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeAtom();
+  });
+  test("[role=textbox]である", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("textbox")).toBeInTheDocument();
   });
-  test("[role=spinbutton]であること", () => {
+  test("[role=spinbutton]である", () => {
     const { getByRole } = render(<Spinbutton />);
     expect(getByRole("spinbutton")).toBeInTheDocument();
   });

--- a/src/components/hooks/useLogout.test.tsx
+++ b/src/components/hooks/useLogout.test.tsx
@@ -7,12 +7,12 @@ import { useLogout } from "./useLogout";
 
 describe("src/components/hooks/useLogout.test.tsx", () => {
   const server = setupMockServer(postLogoutHandler());
-  test("ログアウトに成功した時、トップに遷移すること", async () => {
+  test("ログアウトに成功した時、トップに遷移する", async () => {
     const { result } = renderHook(() => useLogout());
     await result.current();
     expect(window.location.href).toBe("http://localhost/");
   });
-  test("ログアウトに失敗した時、アラートが表示されること", async () => {
+  test("ログアウトに失敗した時、アラートが表示される", async () => {
     window.alert = jest.fn();
     server.use(postLogoutHandler({ err: errors["INTERNAL_SERVER"] }));
     const { result } = renderHook(() => useLogout());

--- a/src/components/layouts/BasicLayout/BasicLayout.test.tsx
+++ b/src/components/layouts/BasicLayout/BasicLayout.test.tsx
@@ -7,14 +7,14 @@ import { BasicLayoutPortal } from "./BasicLayoutPortal";
 const { Default } = composeStories(stories);
 
 describe("src/components/layouts/BasicLayout/BasicLayout.test.tsx", () => {
-  test("主要ランドマークを識別できること", () => {
+  test("主要ランドマークを識別できる", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("banner")).toBeInTheDocument();
     expect(getByRole("complementary")).toBeInTheDocument();
     expect(getByRole("contentinfo")).toBeInTheDocument();
   });
 
-  test("#portal-root 要素が存在しない場合、例外を throw すること", () => {
+  test("#portal-root 要素が存在しない場合、例外を throw する", () => {
     expect(() => BasicLayoutPortal({ children: null })).toThrow();
   });
 });

--- a/src/components/molecules/HeadGroup/HeadGroup.test.tsx
+++ b/src/components/molecules/HeadGroup/HeadGroup.test.tsx
@@ -8,7 +8,11 @@ const { Default } = composeStories(stories);
 
 describe("src/components/molecules/HeadGroup/HeadGroup.test.tsx", () => {
   setupMockServer();
-  test("エリア が title 由来のアクセシブルネームで識別できること", () => {
+  test("Molecule である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeMolecule();
+  });
+  test("エリア が title 由来のアクセシブルネームで識別できる", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("banner", { name: "タイトル" })).toBeInTheDocument();
   });
@@ -16,7 +20,7 @@ describe("src/components/molecules/HeadGroup/HeadGroup.test.tsx", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("heading")).toBeInTheDocument();
   });
-  test("children を render できること", () => {
+  test("children を render できる", () => {
     const { getByText } = render(<Default>テキスト</Default>);
     expect(getByText("テキスト")).toBeInTheDocument();
   });

--- a/src/components/molecules/Table/Table.test.tsx
+++ b/src/components/molecules/Table/Table.test.tsx
@@ -9,11 +9,16 @@ const { Default } = composeStories(stories);
 
 describe("src/components/molecules/Table/Table.test.tsx", () => {
   setupMockServer(createUserHandler());
-  test("[role=table]であること", () => {
+
+  test("Molecule である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeMolecule();
+  });
+  test("[role=table]である", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("table")).toBeInTheDocument();
   });
-  test("aria-label で特定の cell にアクセスできること", () => {
+  test("aria-label で特定の cell にアクセスできる", () => {
     const { getByRole } = render(<Default />);
     const row = within(getByRole("row", { name: "row2" }));
     const cell = row.getByRole("cell", { name: "learnmore" });

--- a/src/components/molecules/TextareaWithTitle/TextareaWithTitle.test.tsx
+++ b/src/components/molecules/TextareaWithTitle/TextareaWithTitle.test.tsx
@@ -8,23 +8,27 @@ const { Default, HasDescription, HasError, FullProps } =
 
 describe("src/components/molecules/TextareaWithTitle/TextareaWithTitle.test.tsx", () => {
   const options: ByRoleOptions = { name: "本文" };
-  test("labeltext が textbox のアクセシブルネームであること", () => {
+  test("Molecule である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeMolecule();
+  });
+  test("labeltext が textbox のアクセシブルネームである", () => {
     const { getByRole } = render(<Default />);
     const textbox = getByRole("textbox", options);
     expect(textbox).toBeInTheDocument();
   });
-  test("description で textbox が識別されていること", () => {
+  test("description で textbox が識別されている", () => {
     const { getByRole } = render(<HasDescription />);
     const textbox = getByRole("textbox", options);
     expect(textbox).toHaveAccessibleDescription("本文を入力してください");
   });
-  test("error で textbox が識別されていること", () => {
+  test("error で textbox が識別されている", () => {
     const { getByRole } = render(<HasError />);
     const textbox = getByRole("textbox", options);
     expect(textbox).toHaveErrorMessage("使用できない文字があります");
     expect(textbox).toBeInvalid();
   });
-  test("description と error で textbox が識別されていること", () => {
+  test("description と error で textbox が識別されている", () => {
     const { getByRole } = render(<FullProps />);
     const textbox = getByRole("textbox", options);
     expect(textbox).toHaveAccessibleDescription("本文を入力してください");

--- a/src/components/molecules/TextboxWithTitle/TextboxWithTitle.test.tsx
+++ b/src/components/molecules/TextboxWithTitle/TextboxWithTitle.test.tsx
@@ -8,23 +8,27 @@ const { Default, HasDescription, HasError, FullProps } =
 
 describe("src/components/TextboxWithTitle/TextboxWithTitle.test.tsx", () => {
   const options: ByRoleOptions = { name: "お名前" };
-  test("labeltext が textbox のアクセシブルネームであること", () => {
+  test("Molecule である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeMolecule();
+  });
+  test("labeltext が textbox のアクセシブルネームである", () => {
     const { getByRole } = render(<Default />);
     const textbox = getByRole("textbox", options);
     expect(textbox).toBeInTheDocument();
   });
-  test("description で textbox が識別されていること", () => {
+  test("description で textbox が識別されている", () => {
     const { getByRole } = render(<HasDescription />);
     const textbox = getByRole("textbox", options);
     expect(textbox).toHaveAccessibleDescription("姓名を入力してください");
   });
-  test("error で textbox が識別されていること", () => {
+  test("error で textbox が識別されている", () => {
     const { getByRole } = render(<HasError />);
     const textbox = getByRole("textbox", options);
     expect(textbox).toHaveErrorMessage("入力エラーがあります");
     expect(textbox).toBeInvalid();
   });
-  test("description と error で textbox が識別されていること", () => {
+  test("description と error で textbox が識別されている", () => {
     const { getByRole } = render(<FullProps />);
     const textbox = getByRole("textbox", options);
     expect(textbox).toHaveAccessibleDescription("姓名を入力してください");

--- a/src/components/organisms/BasicAside/BasicAside.test.tsx
+++ b/src/components/organisms/BasicAside/BasicAside.test.tsx
@@ -9,11 +9,15 @@ const { Default } = composeStories(stories);
 
 describe("src/components/organisms/BasicAside/BasicAside.test.tsx", () => {
   const user = userEvent.setup();
-  test("[role=complementary]であること", () => {
+  test("Organism である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeOrganism();
+  });
+  test("[role=complementary]である", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("complementary")).toBeInTheDocument();
   });
-  test("[role=navigation]を保持していること", () => {
+  test("[role=navigation]を保持している", () => {
     const { getByRole } = render(<Default />);
     expect(
       getByRole("navigation", { name: "メインナビゲーション" })
@@ -31,7 +35,7 @@ describe("src/components/organisms/BasicAside/BasicAside.test.tsx", () => {
       expect(singletonRouter).toMatchObject({ asPath });
     }
   );
-  test("「ログアウト」リンクを押下すると、トップ画面に遷移すること", async () => {
+  test("「ログアウト」リンクを押下すると、トップ画面に遷移する", async () => {
     const { getByRole } = render(<Default />);
     await user.click(getByRole("link", { name: "ログアウト" }));
     expect(window.location.href).toBe("http://localhost/");

--- a/src/components/organisms/BasicFooter/BasicFooter.test.tsx
+++ b/src/components/organisms/BasicFooter/BasicFooter.test.tsx
@@ -6,7 +6,11 @@ import * as stories from "./BasicFooter.stories";
 const { Default } = composeStories(stories);
 
 describe("src/components/organisms/BasicFooter/BasicFooter.test.tsx", () => {
-  test("[role=contentinfo]であること", () => {
+  test("Organism である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeOrganism();
+  });
+  test("[role=contentinfo]である", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("contentinfo")).toBeInTheDocument();
   });

--- a/src/components/organisms/BasicFooter/BasicFooter.tsx
+++ b/src/components/organisms/BasicFooter/BasicFooter.tsx
@@ -2,5 +2,9 @@ import { memo } from "react";
 import styles from "./styles.module.css";
 
 export const BasicFooter = memo(function BasicFooterBase() {
-  return <footer className={styles.footer}></footer>;
+  return (
+    <footer className={styles.footer}>
+      <h2 className={styles.heading}>My CRUD Application</h2>
+    </footer>
+  );
 });

--- a/src/components/organisms/BasicFooter/styles.module.css
+++ b/src/components/organisms/BasicFooter/styles.module.css
@@ -2,3 +2,10 @@
   height: 120px;
   background-color: #f0f1f3;
 }
+
+.heading {
+  padding: 40px;
+  font-size: 12px;
+  text-align: center;
+  color: #b0b0b0;
+}

--- a/src/components/organisms/BasicHeader/BasicHeader.test.tsx
+++ b/src/components/organisms/BasicHeader/BasicHeader.test.tsx
@@ -6,7 +6,11 @@ import * as stories from "./BasicHeader.stories";
 const { Default } = composeStories(stories);
 
 describe("src/components/organisms/BasicHeader/BasicHeader.test.tsx", () => {
-  test("[role=banner]であること", () => {
+  test("Organism である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeOrganism();
+  });
+  test("[role=banner]である", () => {
     const { getByRole } = render(<Default />);
     expect(getByRole("banner")).toBeInTheDocument();
   });

--- a/src/components/organisms/PostForm/PostForm.test.tsx
+++ b/src/components/organisms/PostForm/PostForm.test.tsx
@@ -6,12 +6,16 @@ import * as stories from "./PostForm.stories";
 const { Default, EmptyPost, EditUser } = composeStories(stories);
 
 describe("src/components/organisms/PostForm/PostForm.test.tsx", () => {
-  test("form が title 由来のアクセシブルネームで識別できること", () => {
+  test("Organism である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeOrganism();
+  });
+  test("form が title 由来のアクセシブルネームで識別できる", () => {
     const { getByRole } = render(<Default />);
     const form = getByRole("form", { name: "投稿作成" });
     expect(form).toBeInTheDocument();
   });
-  test("空で送信した場合、入力を促すエラーメッセージが表示されること", async () => {
+  test("空で送信した場合、入力を促すエラーメッセージが表示される", async () => {
     const { container, getByRole, getByLabelText } = render(<EmptyPost />);
     await EmptyPost.play({ canvasElement: container });
     await waitFor(() => {
@@ -23,7 +27,7 @@ describe("src/components/organisms/PostForm/PostForm.test.tsx", () => {
       "著者を入力してください"
     );
   });
-  test("ユーザー編集の場合、初期値が入力されていること", async () => {
+  test("ユーザー編集の場合、初期値が入力されている", async () => {
     const { getByRole } = render(<EditUser />);
     const textbox = getByRole("form", { name: "投稿編集" });
     expect(textbox).toBeInTheDocument();

--- a/src/components/organisms/UserForm/UserForm.test.tsx
+++ b/src/components/organisms/UserForm/UserForm.test.tsx
@@ -6,12 +6,16 @@ import * as stories from "./UserForm.stories";
 const { Default, EmptyPost, InvalidInputs, EditUser } = composeStories(stories);
 
 describe("src/components/organisms/UserForm/UserForm.test.tsx", () => {
-  test("form が title 由来のアクセシブルネームで識別できること", () => {
+  test("Organism である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeOrganism();
+  });
+  test("form が title 由来のアクセシブルネームで識別できる", () => {
     const { getByRole } = render(<Default />);
     const form = getByRole("form", { name: "ユーザー作成" });
     expect(form).toBeInTheDocument();
   });
-  test("空で送信した場合、入力を促すエラーメッセージが表示されること", async () => {
+  test("空で送信した場合、入力を促すエラーメッセージが表示される", async () => {
     const { container, getByRole } = render(<EmptyPost />);
     await EmptyPost.play({ canvasElement: container });
     await waitFor(() => {
@@ -23,7 +27,7 @@ describe("src/components/organisms/UserForm/UserForm.test.tsx", () => {
       "メールアドレスを入力してください"
     );
   });
-  test("不正な文字列で送信した場合、バリデーションエラーメッセージが表示されること", async () => {
+  test("不正な文字列で送信した場合、バリデーションエラーメッセージが表示される", async () => {
     const { container, getByRole } = render(<InvalidInputs />);
     await InvalidInputs.play({ canvasElement: container });
     await waitFor(() => {
@@ -32,7 +36,7 @@ describe("src/components/organisms/UserForm/UserForm.test.tsx", () => {
       ).toHaveErrorMessage("不正なメールアドレス形式です");
     });
   });
-  test("ユーザー編集の場合、初期値が入力されていること", async () => {
+  test("ユーザー編集の場合、初期値が入力されている", async () => {
     const { getByRole } = render(<EditUser />);
     const textbox = getByRole("form", { name: "ユーザー編集" });
     expect(textbox).toBeInTheDocument();

--- a/src/components/templates/Error/Error.test.tsx
+++ b/src/components/templates/Error/Error.test.tsx
@@ -6,8 +6,8 @@ import * as stories from "./Error.stories";
 const { Default } = composeStories(stories);
 
 describe("src/components/templates/Error/Error.test.tsx", () => {
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    expect(getByRole("main")).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
 });

--- a/src/components/templates/Login/Login.test.tsx
+++ b/src/components/templates/Login/Login.test.tsx
@@ -11,17 +11,16 @@ const { Default } = composeStories(stories);
 
 describe("src/components/templates/Login/Login.test.tsx", () => {
   const user = userEvent.setup();
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    const main = getByRole("main");
-    expect(main).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
   describe("フォーム機能", () => {
     const email = "test.user_1@example.com";
     const password = "xxx-xxxxxxxxxx";
     const mock = jest.fn();
     const server = setupMockServer(postLoginHandler({ mock }));
-    test("ログインボタンを押下すると、ログインAPIが呼ばれること", async () => {
+    test("ログインボタンを押下すると、ログインAPIが呼ばれる", async () => {
       const { getByRole, getByLabelText } = render(<Default />);
       await user.type(getByRole("textbox", { name: "メールアドレス" }), email);
       await user.type(getByLabelText("パスワード"), password);
@@ -30,7 +29,7 @@ describe("src/components/templates/Login/Login.test.tsx", () => {
         expect(mock).toHaveBeenCalledWith({ email, password })
       );
     });
-    test("サーバーエラーが発生した時、ログアウトに失敗した旨が表示されること", async () => {
+    test("サーバーエラーが発生した時、ログアウトに失敗した旨が表示される", async () => {
       window.alert = jest.fn();
       server.use(postLoginHandler({ err: errors["INTERNAL_SERVER"] }));
       const { getByRole, getByLabelText } = render(<Default />);

--- a/src/components/templates/Post/Post.test.tsx
+++ b/src/components/templates/Post/Post.test.tsx
@@ -12,12 +12,11 @@ const { Default } = composeStories(stories);
 describe("src/components/templates/Post/Post.test.tsx", () => {
   setupMockServer(createUserHandler());
   const user = userEvent.setup();
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    const main = getByRole("main");
-    expect(main).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
-  test("編集ボタンを押下すると、編集画面に遷移すること", async () => {
+  test("編集ボタンを押下すると、編集画面に遷移する", async () => {
     const { getByRole } = render(<Default />);
     await user.click(getByRole("button", { name: "編集する" }));
     expect(singletonRouter).toMatchObject({ asPath: "/posts/1/edit" });

--- a/src/components/templates/PostEdit/PostEdit.test.tsx
+++ b/src/components/templates/PostEdit/PostEdit.test.tsx
@@ -14,13 +14,12 @@ const { Default, SucceedPost, ServerError } = composeStories(stories);
 describe("src/components/templates/PostEdit/PostEdit.test.tsx", () => {
   const server = setupMockServer(updatePostHandler());
   const user = userEvent.setup();
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    const main = getByRole("main");
-    expect(main).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
   describe("入力フォーム", () => {
-    test("正常入力値で送信すると、API が呼ばれること", async () => {
+    test("正常入力値で送信すると、API が呼ばれる", async () => {
       const mock = jest.fn();
       server.use(updatePostHandler({ mock }));
       const { getByRole } = render(<Default />);
@@ -30,7 +29,7 @@ describe("src/components/templates/PostEdit/PostEdit.test.tsx", () => {
         expect(mock).toHaveBeenCalledWith(expect.objectContaining(actualData))
       );
     });
-    test("正常入力値で送信した場合、成功した旨が表示され、投稿詳細画面に遷移すること", async () => {
+    test("正常入力値で送信した場合、成功した旨が表示され、投稿詳細画面に遷移する", async () => {
       server.use(...storyHandlers(SucceedPost));
       const { container, findByRole } = render(<SucceedPost />);
       await SucceedPost.play({ canvasElement: container });
@@ -39,7 +38,7 @@ describe("src/components/templates/PostEdit/PostEdit.test.tsx", () => {
       );
       expect(singletonRouter).toMatchObject({ asPath: "/posts/1" });
     });
-    test("エラーが返ってきた場合、エラーが表示されること", async () => {
+    test("エラーが返ってきた場合、エラーが表示される", async () => {
       server.use(...storyHandlers(ServerError));
       const { container, findByRole } = render(<ServerError />);
       await ServerError.play({ canvasElement: container });

--- a/src/components/templates/Posts/Posts.test.tsx
+++ b/src/components/templates/Posts/Posts.test.tsx
@@ -11,18 +11,17 @@ const { Default } = composeStories(stories);
 describe("src/components/templates/Posts/Posts.test.tsx", () => {
   setupMockServer();
   const user = userEvent.setup();
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    const main = getByRole("main");
-    expect(main).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
-  test("「詳細」リンクを押下すると、詳細画面に遷移すること", async () => {
+  test("「詳細」リンクを押下すると、詳細画面に遷移する", async () => {
     const { getByRole } = render(<Default />);
     const row = getByRole("row", { name: "Lorem Ipsum 1" });
     await user.click(within(row).getByRole("link", { name: "詳細" }));
     expect(singletonRouter).toMatchObject({ asPath: "/posts/1" });
   });
-  test("「ユーザー新規作成」ボタンを押下すると、ユーザー新規作成画面に遷移すること", async () => {
+  test("「ユーザー新規作成」ボタンを押下すると、ユーザー新規作成画面に遷移する", async () => {
     const { getByRole } = render(<Default />);
     await user.click(getByRole("button", { name: "新規作成" }));
     expect(singletonRouter).toMatchObject({ asPath: "/posts/new" });

--- a/src/components/templates/PostsNew/PostsNew.test.tsx
+++ b/src/components/templates/PostsNew/PostsNew.test.tsx
@@ -14,13 +14,12 @@ const { Default, SucceedPost, ServerError } = composeStories(stories);
 describe("src/components/templates/PostsNew/PostsNew.test.tsx", () => {
   const server = setupMockServer(createPostHandler());
   const user = userEvent.setup();
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    const main = getByRole("main");
-    expect(main).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
   describe("入力フォーム", () => {
-    test("正常入力値で送信すると、API が呼ばれること", async () => {
+    test("正常入力値で送信すると、API が呼ばれる", async () => {
       const mock = jest.fn();
       server.use(createPostHandler({ mock }));
       const { getByRole } = render(<Default />);
@@ -30,7 +29,7 @@ describe("src/components/templates/PostsNew/PostsNew.test.tsx", () => {
         expect(mock).toHaveBeenCalledWith(expect.objectContaining(actualData))
       );
     });
-    test("正常入力値で送信した場合、成功した旨が表示され、投稿詳細画面に遷移すること", async () => {
+    test("正常入力値で送信した場合、成功した旨が表示され、投稿詳細画面に遷移する", async () => {
       server.use(...storyHandlers(SucceedPost));
       const { container, findByRole } = render(<SucceedPost />);
       await SucceedPost.play({ canvasElement: container });
@@ -39,7 +38,7 @@ describe("src/components/templates/PostsNew/PostsNew.test.tsx", () => {
       );
       expect(singletonRouter).toMatchObject({ asPath: "/posts/0" });
     });
-    test("エラーが返ってきた場合、エラーが表示されること", async () => {
+    test("エラーが返ってきた場合、エラーが表示される", async () => {
       server.use(...storyHandlers(ServerError));
       const { container, findByRole } = render(<ServerError />);
       await ServerError.play({ canvasElement: container });

--- a/src/components/templates/Top/Top.test.tsx
+++ b/src/components/templates/Top/Top.test.tsx
@@ -12,10 +12,9 @@ const { Default } = composeStories(stories);
 describe("src/components/templates/Top/Top.test.tsx", () => {
   setupMockServer(createUserHandler());
   const user = userEvent.setup();
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    const main = getByRole("main");
-    expect(main).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
   test.each([
     { name: "ユーザー一覧", asPath: "/users" },

--- a/src/components/templates/User/User.test.tsx
+++ b/src/components/templates/User/User.test.tsx
@@ -12,12 +12,11 @@ const { Default } = composeStories(stories);
 describe("src/components/templates/User/User.test.tsx", () => {
   setupMockServer(createUserHandler());
   const user = userEvent.setup();
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    const main = getByRole("main");
-    expect(main).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
-  test("編集ボタンを押下すると、編集画面に遷移すること", async () => {
+  test("編集ボタンを押下すると、編集画面に遷移する", async () => {
     const { getByRole } = render(<Default />);
     await user.click(getByRole("button", { name: "編集する" }));
     expect(singletonRouter).toMatchObject({ asPath: "/users/1/edit" });

--- a/src/components/templates/UserEdit/UserEdit.test.tsx
+++ b/src/components/templates/UserEdit/UserEdit.test.tsx
@@ -14,13 +14,12 @@ const { Default, SucceedPost, ServerError } = composeStories(stories);
 describe("src/components/templates/UserEdit/UserEdit.test.tsx", () => {
   const server = setupMockServer(updateUserHandler());
   const user = userEvent.setup();
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    const main = getByRole("main");
-    expect(main).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
   describe("入力フォーム", () => {
-    test("正常入力値で送信すると、API が呼ばれること", async () => {
+    test("正常入力値で送信すると、API が呼ばれる", async () => {
       const mock = jest.fn();
       server.use(updateUserHandler({ mock }));
       const { getByRole } = render(<Default />);
@@ -30,7 +29,7 @@ describe("src/components/templates/UserEdit/UserEdit.test.tsx", () => {
         expect(mock).toHaveBeenCalledWith(expect.objectContaining(actualData))
       );
     });
-    test("正常入力値で送信した場合、成功した旨が表示され、ユーザー詳細画面に遷移すること", async () => {
+    test("正常入力値で送信した場合、成功した旨が表示され、ユーザー詳細画面に遷移する", async () => {
       server.use(...storyHandlers(SucceedPost));
       const { container, findByRole } = render(<SucceedPost />);
       await SucceedPost.play({ canvasElement: container });
@@ -39,7 +38,7 @@ describe("src/components/templates/UserEdit/UserEdit.test.tsx", () => {
       );
       expect(singletonRouter).toMatchObject({ asPath: "/users/1" });
     });
-    test("エラーが返ってきた場合、エラーが表示されること", async () => {
+    test("エラーが返ってきた場合、エラーが表示される", async () => {
       server.use(...storyHandlers(ServerError));
       const { container, findByRole } = render(<ServerError />);
       await ServerError.play({ canvasElement: container });

--- a/src/components/templates/Users/Users.test.tsx
+++ b/src/components/templates/Users/Users.test.tsx
@@ -11,18 +11,17 @@ const { Default } = composeStories(stories);
 describe("src/components/templates/Users/Users.test.tsx", () => {
   setupMockServer();
   const user = userEvent.setup();
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    const main = getByRole("main");
-    expect(main).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
-  test("「詳細」リンクを押下すると、詳細画面に遷移すること", async () => {
+  test("「詳細」リンクを押下すると、詳細画面に遷移する", async () => {
     const { getByRole } = render(<Default />);
     const row = getByRole("row", { name: "test.user_1" });
     await user.click(within(row).getByRole("link", { name: "詳細" }));
     expect(singletonRouter).toMatchObject({ asPath: "/users/1" });
   });
-  test("「ユーザー新規作成」ボタンを押下すると、ユーザー新規作成画面に遷移すること", async () => {
+  test("「ユーザー新規作成」ボタンを押下すると、ユーザー新規作成画面に遷移する", async () => {
     const { getByRole } = render(<Default />);
     await user.click(getByRole("button", { name: "新規作成" }));
     expect(singletonRouter).toMatchObject({ asPath: "/users/new" });

--- a/src/components/templates/UsersNew/UsersNew.test.tsx
+++ b/src/components/templates/UsersNew/UsersNew.test.tsx
@@ -13,13 +13,12 @@ const { Default, SucceedPost, ServerError } = composeStories(stories);
 describe("src/components/templates/UsersNew/UsersNew.test.tsx", () => {
   const server = setupMockServer(createUserHandler());
   const user = userEvent.setup();
-  test("main ランドマークを1つ識別できること", () => {
-    const { getByRole } = render(<Default />);
-    const main = getByRole("main");
-    expect(main).toBeInTheDocument();
+  test("Template である", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
   });
   describe("入力フォーム", () => {
-    test("正常入力値で送信すると、API が呼ばれること", async () => {
+    test("正常入力値で送信すると、API が呼ばれる", async () => {
       const mock = jest.fn();
       server.use(createUserHandler({ mock }));
       const { getByRole } = render(<Default />);
@@ -29,7 +28,7 @@ describe("src/components/templates/UsersNew/UsersNew.test.tsx", () => {
         expect(mock).toHaveBeenCalledWith(expect.objectContaining(actualData))
       );
     });
-    test("正常入力値で送信した場合、成功した旨が表示されること", async () => {
+    test("正常入力値で送信した場合、成功した旨が表示される", async () => {
       server.use(...storyHandlers(SucceedPost));
       const { container, findByRole } = render(<SucceedPost />);
       await SucceedPost.play({ canvasElement: container });
@@ -37,7 +36,7 @@ describe("src/components/templates/UsersNew/UsersNew.test.tsx", () => {
         "ユーザーの作成に成功しました"
       );
     });
-    test("エラーが返ってきた場合、エラーが表示されること", async () => {
+    test("エラーが返ってきた場合、エラーが表示される", async () => {
       server.use(...storyHandlers(ServerError));
       const { container, findByRole } = render(<ServerError />);
       await ServerError.play({ canvasElement: container });

--- a/src/tests/jest.customMatchers.test.tsx
+++ b/src/tests/jest.customMatchers.test.tsx
@@ -1,0 +1,274 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+
+describe("Template", () => {
+  test("<main>(role=main)", () => {
+    const { container } = render(
+      <main>
+        <h2>Test</h2>
+        <button>+1</button>
+      </main>
+    );
+    expect(container).not.toBeAtom();
+    expect(container).not.toBeMolecule();
+    expect(container).not.toBeOrganism();
+    expect(container).toBeTemplate();
+  });
+});
+
+describe("Organisms", () => {
+  function asserts(container: HTMLElement) {
+    expect(container).not.toBeAtom();
+    expect(container).not.toBeMolecule();
+    expect(container).toBeOrganism();
+    expect(container).not.toBeTemplate();
+  }
+  test("<aside>(role=complementary)", () => {
+    const { container } = render(
+      <aside>
+        <h2>Test</h2>
+        <button>+1</button>
+      </aside>
+    );
+    asserts(container);
+  });
+  test("<form>(role=form)", () => {
+    const { container } = render(
+      <form aria-labelledby="test">
+        <h2 id="test">Test</h2>
+        <button>+1</button>
+      </form>
+    );
+    asserts(container);
+  });
+  test("<form>(role=search)", () => {
+    const { container } = render(
+      <form role="search">
+        <h2>Test</h2>
+        <button>+1</button>
+      </form>
+    );
+    asserts(container);
+  });
+  test("<nav>(role=navigation)", () => {
+    const { container } = render(
+      <nav>
+        <h2>Test</h2>
+        <button>+1</button>
+      </nav>
+    );
+    asserts(container);
+  });
+  test("<section>(role=region)", () => {
+    const { container } = render(
+      <section aria-labelledby="test">
+        <h2 id="test">Test</h2>
+        <button>+1</button>
+      </section>
+    );
+    asserts(container);
+  });
+  test("<div>(role=alertdialog)", () => {
+    const { container } = render(
+      <div role="alertdialog">
+        <h2 id="test">Test</h2>
+        <button>+1</button>
+      </div>
+    );
+    asserts(container);
+  });
+  test("<div>(role=dialog)", () => {
+    const { container } = render(
+      <div role="dialog">
+        <h2 id="test">Test</h2>
+        <button>+1</button>
+      </div>
+    );
+    asserts(container);
+  });
+});
+
+describe("Molecules", () => {
+  function asserts(container: HTMLElement) {
+    expect(container).not.toBeAtom();
+    expect(container).toBeMolecule();
+    expect(container).not.toBeOrganism();
+    expect(container).not.toBeTemplate();
+  }
+  test("<form>(role=none)", () => {
+    const { container } = render(
+      <form>
+        <h2>Test</h2>
+        <button>+1</button>
+      </form>
+    );
+    asserts(container);
+  });
+  test("<div>(role=group)", () => {
+    const { container } = render(
+      <div role="group">
+        <h2>Test</h2>
+      </div>
+    );
+    asserts(container);
+  });
+  test("<article>(role=artilce)", () => {
+    const { container } = render(
+      <article>
+        <h2>Test</h2>
+      </article>
+    );
+    asserts(container);
+  });
+  test("<ul>(role=list)", () => {
+    const { container } = render(
+      <ul>
+        <li></li>
+      </ul>
+    );
+    asserts(container);
+  });
+  test("<ol>(role=list)", () => {
+    const { container } = render(
+      <ol>
+        <li></li>
+      </ol>
+    );
+    asserts(container);
+  });
+  test("<dl>(role=term)", () => {
+    const { container } = render(
+      <dl>
+        <dt></dt>
+        <dd></dd>
+      </dl>
+    );
+    asserts(container);
+  });
+  test("<div>(role=tablist)", () => {
+    const { container } = render(
+      <div role="tablist">
+        <p role="tab"></p>
+      </div>
+    );
+    asserts(container);
+  });
+  test("<div>(role=tabpanel)", () => {
+    const { container } = render(
+      <div role="tabpanel">
+        <h2>Test</h2>
+      </div>
+    );
+    asserts(container);
+  });
+  test("<table>(role=table)", () => {
+    const { container } = render(
+      <table>
+        <thead>
+          <tr />
+        </thead>
+        <tbody>
+          <tr />
+        </tbody>
+      </table>
+    );
+    asserts(container);
+  });
+  test("<select>(role=combobox)", () => {
+    const { container } = render(
+      <select>
+        <option value={0}>A</option>
+        <option value={1}>B</option>
+      </select>
+    );
+    asserts(container);
+  });
+  test("<section>(multiple roles)", () => {
+    const { container } = render(
+      <section>
+        <h2 id="test">Test</h2>
+        <button>+1</button>
+      </section>
+    );
+    asserts(container);
+  });
+});
+
+describe("Organisms or Molecules", () => {
+  // MEMO: header footer は構成 Node によって AsNonLandmark になりえるため
+  function asserts(container: HTMLElement) {
+    expect(container).not.toBeAtom();
+    expect(container).toBeMolecule();
+    expect(container).toBeOrganism();
+    expect(container).not.toBeTemplate();
+  }
+  test("<header>(role=banner)", () => {
+    const { container } = render(
+      <header>
+        <h2>Test</h2>
+        <button>+1</button>
+      </header>
+    );
+    asserts(container);
+  });
+  test("<footer>(role=contentinfo)", () => {
+    const { container } = render(
+      <footer>
+        <h2>Test</h2>
+        <button>+1</button>
+      </footer>
+    );
+    asserts(container);
+  });
+});
+
+describe("Atoms", () => {
+  function asserts(container: HTMLElement) {
+    expect(container).toBeAtom();
+    expect(container).not.toBeMolecule();
+    expect(container).not.toBeOrganism();
+    expect(container).not.toBeTemplate();
+  }
+  test("<p>(role=none)", () => {
+    const { container } = render(<p>test</p>);
+    asserts(container);
+  });
+  test("<h1>(role=heading)", () => {
+    const { container } = render(<h1>test</h1>);
+    asserts(container);
+  });
+  test("<a>(role=link)", () => {
+    const { container } = render(<a href="#">test</a>);
+    asserts(container);
+  });
+  test("<button>(role=button)", () => {
+    const { container } = render(<button>test</button>);
+    asserts(container);
+  });
+  test("<input>(role=textbox)", () => {
+    const { container } = render(<input type="text" />);
+    asserts(container);
+  });
+  test("<textarea>(role=textbox)", () => {
+    const { container } = render(<textarea />);
+    asserts(container);
+  });
+  test("<div>(single role)", () => {
+    const { container } = render(
+      <div>
+        <img alt="picture" />
+        <p>test</p>
+      </div>
+    );
+    asserts(container);
+  });
+
+  test("<textaresda>(role=textbox)", () => {
+    const { container } = render(
+      <div>
+        <p>aa</p>
+      </div>
+    );
+    asserts(container);
+  });
+});

--- a/src/tests/jest.customMatchers.ts
+++ b/src/tests/jest.customMatchers.ts
@@ -1,0 +1,140 @@
+import { getRoles } from "@testing-library/react";
+
+export interface CustomMatchers<R> extends Record<string, any> {
+  toBeAtom: () => R;
+  toBeMolecule: () => R;
+  toBeOrganism: () => R;
+  toBeTemplate: () => R;
+}
+
+declare global {
+  namespace jest {
+    interface Matchers<R, T = {}> extends CustomMatchers<R> {}
+  }
+}
+
+const groupRoles = [
+  "group",
+  "article",
+  "list",
+  "term",
+  "tablist",
+  "tabpanel",
+  "table",
+  "rowgroup",
+  "row",
+  "combobox",
+];
+
+const maybeLandmarkRoles = ["banner", "contentinfo"];
+
+const landmarkRoles = [
+  "complementary",
+  "form",
+  // "main",
+  "navigation",
+  "region",
+  "search",
+];
+
+const windowRoles = ["alertdialog", "dialog"];
+
+const ignoresRoles = ["generic", "presentation"];
+
+function includeGroupRole(keys: string[]) {
+  return keys.map((key) => groupRoles.includes(key)).some(Boolean);
+}
+
+function includeMaybeLandmarkRole(keys: string[]) {
+  return keys.map((key) => maybeLandmarkRoles.includes(key)).some(Boolean);
+}
+
+function includeLandmarkRole(keys: string[]) {
+  return keys.map((key) => landmarkRoles.includes(key)).some(Boolean);
+}
+
+function includeWindowRole(keys: string[]) {
+  return keys.map((key) => windowRoles.includes(key)).some(Boolean);
+}
+
+function includeMainRole(keys: string[]) {
+  return keys.includes("main");
+}
+
+function getRoleKeys(container: HTMLElement) {
+  return Object.keys(getRoles(container)).filter(
+    (key) => !ignoresRoles.includes(key)
+  );
+}
+
+function fail(message: string) {
+  return { pass: false, message: () => message };
+}
+
+function toBeAtom(container: HTMLElement): jest.CustomMatcherResult {
+  const keys = getRoleKeys(container);
+  if (keys.length >= 2) {
+    return fail("Atom should structed by single role.");
+  }
+  if (includeGroupRole(keys)) {
+    return fail("Atom should not include group role.");
+  }
+  if (includeWindowRole(keys)) {
+    return fail("Atom should not include window role.");
+  }
+  if (
+    includeLandmarkRole(keys) ||
+    includeMaybeLandmarkRole(keys) ||
+    includeMainRole(keys)
+  ) {
+    return fail("Atom should not include landmark role.");
+  }
+  return { pass: true, message: () => "it Atom" };
+}
+
+function toBeMolecule(container: HTMLElement): jest.CustomMatcherResult {
+  const keys = getRoleKeys(container);
+  if (!(keys.length >= 2)) {
+    return fail("Molecule should structed by multiple role.");
+  }
+  if (includeLandmarkRole(keys)) {
+    return fail("Molecule should not include landmark role.");
+  }
+  if (includeWindowRole(keys)) {
+    return fail("Molecule should not include window role.");
+  }
+  if (includeMainRole(keys)) {
+    return fail("Molecule should not include main role.");
+  }
+  return { pass: true, message: () => "it Molecule" };
+}
+
+function toBeOrganism(container: HTMLElement): jest.CustomMatcherResult {
+  const keys = getRoleKeys(container);
+  if (!(keys.length >= 2)) {
+    return fail("Organism should structed by multiple role.");
+  }
+  if (
+    !(
+      includeLandmarkRole(keys) ||
+      includeMaybeLandmarkRole(keys) ||
+      includeWindowRole(keys)
+    )
+  ) {
+    return fail("Organism should structed by landmark or window role.");
+  }
+  if (includeMainRole(keys)) {
+    return fail("Organism should not include main role.");
+  }
+  return { pass: true, message: () => "it Organism" };
+}
+
+function toBeTemplate(container: HTMLElement): jest.CustomMatcherResult {
+  const keys = getRoleKeys(container);
+  if (!includeMainRole(keys)) {
+    return fail("Template should include main role.");
+  }
+  return { pass: true, message: () => "it Template" };
+}
+
+expect.extend({ toBeAtom, toBeMolecule, toBeOrganism, toBeTemplate });


### PR DESCRIPTION
## New Testing Feature

Add classification checker for AtomicDesign.
New Custom Matchers assert it is correct classification.

```tsx
const { container } = render(<Component />);
expect(container).not.toBeAtom();
expect(container).toBeMolecule();
expect(container).not.toBeOrganism();
expect(container).not.toBeTemplate();
```